### PR TITLE
Add "use strict"

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const SNOOZES = [
   'fuck off', 
   'later..', 


### PR DESCRIPTION
Google Chrome 48.0.2564.109 (64-bit) on Arch Linux says this: "Uncaught SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode"